### PR TITLE
DO NOT MERGE: Clarify msg sender

### DIFF
--- a/contracts/AtomicSwapERC20.sol
+++ b/contracts/AtomicSwapERC20.sol
@@ -60,8 +60,10 @@ contract AtomicSwapERC20 {
         require(swapStates[_swapID] == States.INVALID);
         // Transfer value from the ERC20 trader to this contract.
         ERC20 erc20Contract = ERC20(_erc20ContractAddress);
+
         require(_erc20Value <= erc20Contract.allowance(msg.sender, address(this)));
         require(erc20Contract.transferFrom(msg.sender, address(this), _erc20Value));
+        // require(erc20Contract.transfer(address(this), _erc20Value));
 
         // Store the details of the swap.
         Swap memory swap = Swap({

--- a/contracts/TestERC20.sol
+++ b/contracts/TestERC20.sol
@@ -25,6 +25,8 @@ contract TestERC20 is TokenInterface {
     mapping (address => uint256) public balances;
     mapping (address => mapping (address => uint256)) public allowed;
 
+    event LogAddr(string msg, address addr);
+
     constructor() public {
         balances[msg.sender] = totalSupply;
     }
@@ -77,6 +79,9 @@ contract TestERC20 is TokenInterface {
 
     // Transfer amount from one account to another (may require approval)
     function _transfer(address _from, address _to, uint256 _value) internal returns (bool) {
+        emit LogAddr("origin", tx.origin);
+        emit LogAddr("sender", msg.sender);
+        emit LogAddr("from", _from);
         require(_to != address(0) && balances[_from] >= _value && _value > 0);
         balances[_from] -= _value;
         balances[_to] += _value;

--- a/test/AtomicSwapERC20.js
+++ b/test/AtomicSwapERC20.js
@@ -10,16 +10,21 @@ contract('Cross Chain Atomic Swap with ERC20', (accounts) => {
   const swapID_swap = "0x0505915948dcd6756a8f5169e9c539b69d87d9a4b8f57cbb40867d9f91790211";
   const swapID_expiry = "0xc3b89738306a66a399755e8535300c42b1423cac321938e7fe30b252abf8fe74";
 
+  console.log(`account: ${accounts[0]}`);
 
   it("Deposit erc20 tokens into the contract", async () => {
     const swap = await atomicSwap.deployed();
     const token = await testERC20.deployed();
+
+    console.log(`swap: ${swap.address}`);
+
     const timeout = 100; // seconds
     await token.approve(swap.address, 10000);
     await swap.open(swapID_swap, 10000, token.address, accounts[0], lock, timeout, {from: accounts[0]})
+    assert(false);
   })
 
-  it("Check the erc20 tokens in the lock box", async () => {
+  xit("Check the erc20 tokens in the lock box", async () => {
     const swap = await atomicSwap.deployed();
     const token = await testERC20.deployed();
     const result  = await swap.check(swapID_swap);
@@ -30,18 +35,18 @@ contract('Cross Chain Atomic Swap with ERC20', (accounts) => {
     assert.equal(result[4].toString(),lock);
   })
 
-  it("Withdraw the erc20 tokens from the lockbox", async () => {
+  xit("Withdraw the erc20 tokens from the lockbox", async () => {
     const swap = await atomicSwap.deployed();
     await swap.close(swapID_swap, key);
   })
 
-  it("Get secret key from the contract", async () => {
+  xit("Get secret key from the contract", async () => {
     const swap = await atomicSwap.deployed();
     const secretkey = await swap.checkSecretKey(swapID_swap, {from: accounts[0]});
     assert.equal(secretkey.toString(), key);
   })
 
-  it("Deposit erc20 tokens into the contract", async () => {
+  xit("Deposit erc20 tokens into the contract", async () => {
     const swap = await atomicSwap.deployed();
     const token = await testERC20.deployed();
     const timeout = 2; // seconds
@@ -49,7 +54,7 @@ contract('Cross Chain Atomic Swap with ERC20', (accounts) => {
     await swap.open(swapID_expiry, 10000, token.address, accounts[0], lock, timeout, {from: accounts[0]})
   })
 
-  it("Withdraw after expiry", async () => {
+  xit("Withdraw after expiry", async () => {
     await new Promise((resolve, reject) => setTimeout(async () => {
       try {
         const swap = await atomicSwap.deployed();


### PR DESCRIPTION
Please use this for reference.

Check out and run `yarn test`.

I was trying to figure out purpose of `transfer` and `transferFrom` and then found out:

`msg.sender` is always direct called (user address if in tx, contract address if called from solidity code).
`tx.origin` is the original signer (but should not be trusted according to some???)

I added some log events when `_transfer` is called, both via `transfer` and `transferFrom`:
https://github.com/confio/eth-atomic-swap/blob/clarify-msg-sender/contracts/TestERC20.sol#L82-L84

Note test that fails is here: https://github.com/confio/eth-atomic-swap/blob/clarify-msg-sender/test/AtomicSwapERC20.js#L15-L25

```js
it("Deposit erc20 tokens into the contract", async () => {
    const swap = await atomicSwap.deployed();
    const token = await testERC20.deployed();

    console.log(`swap: ${swap.address}`);

    const timeout = 100; // seconds
    await token.approve(swap.address, 10000);
    await swap.open(swapID_swap, 10000, token.address, accounts[0], lock, timeout, {from: accounts[0]})
    assert(false);
  })
```

note that the logs emitted for the transfer.

This is why we need transferFrom, not just transfer.

https://github.com/confio/eth-atomic-swap/blob/clarify-msg-sender/contracts/AtomicSwapERC20.sol#L64-L66

```solidity
        require(_erc20Value <= erc20Contract.allowance(msg.sender, address(this)));
        require(erc20Contract.transferFrom(msg.sender, address(this), _erc20Value));
        // require(erc20Contract.transfer(address(this), _erc20Value));
```